### PR TITLE
Fix package initialization and dependency for videoCompress

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Video compression package."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==2.3.2
 Celery==5.3.1
 sqlalchemy==2.0.23
-kombu-driver-sqlalchemy==1.4.0
+kombu-sqlalchemy==1.1.0


### PR DESCRIPTION
## Summary
- add `app/__init__.py` so app modules can be imported
- replace invalid `kombu-driver-sqlalchemy` dependency with `kombu-sqlalchemy==1.1.0`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m app.main` & `curl -s http://localhost:5000/api/dirs`

------
https://chatgpt.com/codex/tasks/task_e_68b69022a26883329766ba8c9a7011b7