### PR TITLE
Fix template lookup for Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Video Compression Service
+
+This project provides a simple web interface and API for compressing videos using [FFmpeg](https://ffmpeg.org/). The service is built with Flask for the HTTP layer and Celery for background processing.
+
+## Important Files and Directories
+
+- `app/main.py` – Flask application that exposes HTTP endpoints and serves the web UI.
+- `app/tasks.py` – Celery task that runs FFmpeg to compress videos.
+- `app/celery_worker.py` – Celery configuration using SQLite for both broker and backend.
+- `app/config.py` – Default input and output directories used by the service.
+- `templates/` – HTML templates for the user interface.
+- `static/` – JavaScript and CSS assets used by the web UI.
+- `requirements.txt` – Python dependencies.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+FFmpeg must be installed separately and available on the system path.
+
+## Testing
+
+```bash
+pytest
+```
+
+## Running the Service
+
+Start a Celery worker:
+
+```bash
+celery -A app.celery_worker worker --loglevel=info
+```
+
+Run the Flask development server:
+
+```bash
+python -m app.main
+```
+
+The application will be available at `http://127.0.0.1:5001` by default.
+

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,11 @@ from app import config
 from app.tasks import compress_video
 from app.log_utils import read_logs
 
-app = Flask(__name__)
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE_DIR = os.path.join(BASE_DIR, "..", "templates")
+STATIC_DIR = os.path.join(BASE_DIR, "..", "static")
+
+app = Flask(__name__, template_folder=TEMPLATE_DIR, static_folder=STATIC_DIR)
 
 # 获取输入输出目录
 @app.route("/api/dirs", methods=["GET"])
@@ -66,7 +70,7 @@ def index():
 
 @app.route("/static/<path:filename>")
 def static_files(filename):
-    return send_from_directory("static", filename)
+    return send_from_directory(STATIC_DIR, filename)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5001)


### PR DESCRIPTION
## Summary
- Configure Flask with explicit template and static directories to ensure `index.html` and assets load correctly

## Testing
- `pytest`
- `python -m app.main` (handled via curl request to `/`)


------
https://chatgpt.com/codex/tasks/task_e_68b6952aecf083328d870e767bfc4435