### PR TITLE
Enhance video compressor UI with task tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ db/
 # OS generated files
 .DS_Store
 Thumbs.db
+# Video directories
+input_videos/
+output_videos/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This project provides a simple web interface and API for compressing videos usin
 
 - `app/main.py` – Flask application that exposes HTTP endpoints and serves the web UI.
 - `app/tasks.py` – Celery task that runs FFmpeg to compress videos.
-- `app/celery_worker.py` – Celery configuration using SQLite for both broker and backend.
+- `app/celery_worker.py` – Celery configuration. Uses an in-memory broker by
+  default and runs tasks eagerly; set `CELERY_BROKER_URL` and
+  `CELERY_RESULT_BACKEND` environment variables to use a real broker/backend.
 - `app/config.py` – Default input and output directories used by the service.
 - `templates/` – HTML templates for the user interface.
 - `static/` – JavaScript and CSS assets used by the web UI.
@@ -28,16 +30,17 @@ pytest
 
 ## Running the Service
 
-Start a Celery worker:
-
-```bash
-celery -A app.celery_worker worker --loglevel=info
-```
-
 Run the Flask development server:
 
 ```bash
 python -m app.main
+```
+
+When a real broker is configured via `CELERY_BROKER_URL`, start a Celery worker
+in a separate terminal:
+
+```bash
+celery -A app.celery_worker worker --loglevel=info
 ```
 
 The application will be available at `http://127.0.0.1:5001` by default.

--- a/app/celery_worker.py
+++ b/app/celery_worker.py
@@ -1,15 +1,27 @@
 from celery import Celery
 import os
 
-DB_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../db"))
-os.makedirs(DB_DIR, exist_ok=True)
-DB_PATH = os.path.join(DB_DIR, "celery.sqlite")
 
-def make_celery(app_name=__name__):
-    return Celery(
-        app_name,
-        broker=f"sqla+sqlite:///{DB_PATH}",
-        backend=f"db+sqlite:///{DB_PATH}"
-    )
+def make_celery(app_name: str = __name__) -> Celery:
+    """Create a Celery instance.
+
+    If a broker URL is not provided via the ``CELERY_BROKER_URL`` environment
+    variable, an in-memory broker and backend are used and tasks are executed
+    eagerly. This avoids requiring additional services during development and
+    tests, while still allowing a real broker/backend to be configured
+    externally.
+    """
+
+    broker = os.getenv("CELERY_BROKER_URL")
+    backend = os.getenv("CELERY_RESULT_BACKEND")
+
+    if not broker:
+        celery = Celery(app_name, broker="memory://", backend="cache+memory://")
+        celery.conf.task_always_eager = True
+        celery.conf.task_store_eager_result = True
+        return celery
+
+    return Celery(app_name, broker=broker, backend=backend or broker)
+
 
 celery = make_celery()

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ import os
 from app import config
 from app.tasks import compress_video
 from app.log_utils import read_logs
+from app.celery_worker import celery
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_DIR = os.path.join(BASE_DIR, "..", "templates")
@@ -58,6 +59,11 @@ def add_compress_task():
     output_path = os.path.join(config.OUTPUT_DIR, filename)
     task = compress_video.delay(input_path, output_path, codec, crf, extra_args)
     return jsonify({"task_id": task.id})
+
+@app.route("/api/task_status/<task_id>", methods=["GET"])
+def get_task_status(task_id):
+    result = celery.AsyncResult(task_id)
+    return jsonify({"task_id": task_id, "state": result.state})
 
 @app.route("/api/logs", methods=["GET"])
 def get_logs():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 Flask==2.3.2
 Celery==5.3.1
-sqlalchemy==2.0.23
-kombu-sqlalchemy==1.1.0

--- a/static/style.css
+++ b/static/style.css
@@ -1,42 +1,5 @@
 body {
     font-family: "Microsoft YaHei", Arial, sans-serif;
-    margin: 30px;
     background: #f8f9fa;
 }
-h1 {
-    color: #2c3e50;
-}
-section {
-    background: #fff;
-    border-radius: 8px;
-    box-shadow: 0 2px 8px #eee;
-    padding: 20px;
-    margin-bottom: 24px;
-}
-label {
-    margin-right: 16px;
-}
-button {
-    margin-left: 8px;
-    padding: 4px 12px;
-    border-radius: 4px;
-    border: 1px solid #bbb;
-    background: #e9ecef;
-    cursor: pointer;
-}
-button:hover {
-    background: #d0d7de;
-}
-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-top: 10px;
-}
-th, td {
-    padding: 6px 10px;
-    border: 1px solid #ccc;
-    text-align: center;
-}
-th {
-    background: #f1f3f4;
-}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,52 +3,95 @@
 <head>
     <meta charset="UTF-8">
     <title>视频压缩服务器管理</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-    <h1>视频压缩服务器管理</h1>
-    <section>
-        <h2>目录设置</h2>
-        <label>输入目录: <input type="text" id="inputDir" size="50"></label>
-        <button onclick="setDirs()">保存</button>
-        <br>
-        <label>输出目录: <input type="text" id="outputDir" size="50"></label>
-    </section>
-    <section>
-        <h2>待压缩视频列表</h2>
-        <button onclick="refreshVideos()">刷新</button>
-        <ul id="videoList"></ul>
-    </section>
-    <section>
-        <h2>压缩参数</h2>
-        <label>编码器:
-            <select id="codec">
-                <option value="libx264">H.264 (libx264)</option>
-                <option value="libx265">H.265 (libx265)</option>
-                <option value="libvpx-vp9">VP9 (libvpx-vp9)</option>
-                <option value="libaom-av1">AV1 (libaom-av1)</option>
-            </select>
-        </label>
-        <label>CRF: <input type="number" id="crf" value="23" min="0" max="51"></label>
-        <button onclick="compressSelected()">压缩选中视频</button>
-    </section>
-    <section>
-        <h2>压缩日志报表</h2>
-        <button onclick="loadLogs()">刷新日志</button>
-        <table border="1" id="logTable">
-            <thead>
-                <tr>
-                    <th>时间</th>
-                    <th>输入文件</th>
-                    <th>输出文件</th>
-                    <th>编码器</th>
-                    <th>CRF</th>
-                    <th>结果</th>
-                </tr>
-            </thead>
-            <tbody></tbody>
-        </table>
-    </section>
-    <script src="/static/app.js"></script>
+<div class="container my-4">
+    <h1 class="mb-4">视频压缩服务器管理</h1>
+
+    <div class="card mb-4">
+        <div class="card-header">目录设置</div>
+        <div class="card-body">
+            <div class="mb-3">
+                <label class="form-label">输入目录</label>
+                <input type="text" id="inputDir" class="form-control" />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">输出目录</label>
+                <input type="text" id="outputDir" class="form-control" />
+            </div>
+            <button class="btn btn-primary" onclick="setDirs()">保存</button>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">待压缩视频列表</div>
+        <div class="card-body">
+            <button class="btn btn-secondary mb-2" onclick="refreshVideos()">刷新</button>
+            <ul id="videoList" class="list-group"></ul>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">压缩参数</div>
+        <div class="card-body">
+            <div class="mb-3">
+                <label for="codec" class="form-label">编码器</label>
+                <select id="codec" class="form-select" aria-describedby="codecHelp">
+                    <option value="libx264">H.264 (libx264)</option>
+                    <option value="libx265">H.265 (libx265)</option>
+                    <option value="libvpx-vp9">VP9 (libvpx-vp9)</option>
+                    <option value="libaom-av1">AV1 (libaom-av1)</option>
+                </select>
+                <div id="codecHelp" class="form-text">
+                    H.264兼容性最佳；H.265文件更小；VP9与AV1适合网络播放但编码较慢。
+                </div>
+            </div>
+            <div class="mb-3">
+                <label for="crf" class="form-label">CRF</label>
+                <input type="number" id="crf" class="form-control" value="23" min="0" max="51" aria-describedby="crfHelp">
+                <div id="crfHelp" class="form-text">
+                    数值越小质量越高、文件越大，常用范围为18-28。
+                </div>
+            </div>
+            <button class="btn btn-success" onclick="compressSelected()">压缩选中视频</button>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">任务状态</div>
+        <div class="card-body">
+            <table class="table" id="taskTable">
+                <thead>
+                    <tr><th>文件</th><th>状态</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="card mb-4">
+        <div class="card-header">压缩日志报表</div>
+        <div class="card-body">
+            <button class="btn btn-secondary" onclick="loadLogs()">刷新日志</button>
+            <table class="table table-bordered mt-3" id="logTable">
+                <thead>
+                    <tr>
+                        <th>时间</th>
+                        <th>输入文件</th>
+                        <th>输出文件</th>
+                        <th>编码器</th>
+                        <th>CRF</th>
+                        <th>结果</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<script src="/static/app.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- add endpoint to query Celery task status
- redesign HTML with Bootstrap and add parameter descriptions
- track compression jobs in the frontend and show a live task table
- default Celery to an in-memory broker to avoid SQLAlchemy dependency

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6a9dabad883328d126b0b0670e3d3