### PR TITLE
feat: list and track compression tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ celery -A app.celery_worker worker --loglevel=info
 
 The application will be available at `http://127.0.0.1:5001` by default.
 
+## API
+
+- `POST /api/compress` – submit a compression task, returns the task ID and confirmation message.
+- `GET /api/tasks` – list all submitted tasks and their current state.
+

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -2,8 +2,8 @@ import subprocess
 from app.celery_worker import celery
 from app.log_utils import log_compress_task
 
-@celery.task
-def compress_video(input_path, output_path, codec="libx264", crf=23, extra_args=None):
+@celery.task(bind=True)
+def compress_video(self, input_path, output_path, codec="libx264", crf=23, extra_args=None):
     """
     input_path: 输入视频路径
     output_path: 输出视频路径
@@ -25,6 +25,7 @@ def compress_video(input_path, output_path, codec="libx264", crf=23, extra_args=
     try:
         result = subprocess.run(cmd, capture_output=True, text=True)
         log_info = {
+            "task_id": self.request.id,
             "input_path": input_path,
             "output_path": output_path,
             "codec": codec,
@@ -42,6 +43,7 @@ def compress_video(input_path, output_path, codec="libx264", crf=23, extra_args=
         }
     except Exception as e:
         log_info = {
+            "task_id": self.request.id,
             "input_path": input_path,
             "output_path": output_path,
             "codec": codec,

--- a/static/app.js
+++ b/static/app.js
@@ -1,4 +1,4 @@
-const tasks = [];
+let tasks = [];
 
 async function fetchDirs() {
     const res = await fetch("/api/dirs");
@@ -46,10 +46,9 @@ async function compressSelected() {
             })
         });
         const data = await res.json();
-        tasks.push({ id: data.task_id, filename: cb.value, state: "PENDING" });
+        alert(`任务已提交: ${data.task_id}`);
     }
-    renderTasks();
-    alert("压缩任务已提交");
+    fetchTasks();
     loadLogs();
 }
 
@@ -82,14 +81,9 @@ function renderTasks() {
     });
 }
 
-async function updateTaskStatuses() {
-    for (const t of tasks) {
-        if (t.state !== "SUCCESS" && t.state !== "FAILURE") {
-            const res = await fetch(`/api/task_status/${t.id}`);
-            const data = await res.json();
-            t.state = data.state;
-        }
-    }
+async function fetchTasks() {
+    const res = await fetch("/api/tasks");
+    tasks = await res.json();
     renderTasks();
 }
 
@@ -97,5 +91,9 @@ window.onload = function() {
     fetchDirs();
     refreshVideos();
     loadLogs();
-    setInterval(updateTaskStatuses, 3000);
+    fetchTasks();
+    setInterval(() => {
+        fetchTasks();
+        loadLogs();
+    }, 3000);
 };


### PR DESCRIPTION
## Summary
- track submitted compression jobs in-memory and expose `/api/tasks`
- add task IDs to log entries and server responses
- update frontend to display and refresh all tasks

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b6aea37874833298b0ffb69b87b399