### PR TITLE
Add task progress display and concurrency limit

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,5 +1,20 @@
 let tasks = [];
 
+async function fetchMaxConcurrent() {
+    const res = await fetch("/api/max_concurrent");
+    const data = await res.json();
+    document.getElementById("maxConcurrent").value = data.max_concurrent_tasks;
+}
+
+async function setMaxConcurrent() {
+    const value = parseInt(document.getElementById("maxConcurrent").value);
+    await fetch("/api/max_concurrent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ max_concurrent_tasks: value })
+    });
+}
+
 async function fetchDirs() {
     const res = await fetch("/api/dirs");
     const data = await res.json();
@@ -35,18 +50,32 @@ async function compressSelected() {
     const codec = document.getElementById("codec").value;
     const crf = parseInt(document.getElementById("crf").value);
     const checkboxes = document.querySelectorAll("#videoList input[type=checkbox]:checked");
+    if (checkboxes.length === 0) {
+        alert("请先选择至少一个视频");
+        return;
+    }
     for (const cb of checkboxes) {
-        const res = await fetch("/api/compress", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-                filename: cb.value,
-                codec: codec,
-                crf: crf
-            })
-        });
-        const data = await res.json();
-        alert(`任务已提交: ${data.task_id}`);
+        try {
+            const res = await fetch("/api/compress", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    filename: cb.value,
+                    codec: codec,
+                    crf: crf
+                })
+            });
+            if (!res.ok) {
+                const text = await res.text();
+                alert(`任务提交失败: ${res.status} ${text}`);
+                continue;
+            }
+            const data = await res.json();
+            alert(`任务已提交: ${data.task_id}`);
+        } catch (err) {
+            console.error(err);
+            alert("提交任务出错");
+        }
     }
     fetchTasks();
     loadLogs();
@@ -76,7 +105,18 @@ function renderTasks() {
     tbody.innerHTML = "";
     tasks.forEach(t => {
         const tr = document.createElement("tr");
-        tr.innerHTML = `<td>${t.filename}</td><td>${t.state}</td>`;
+        const progress = t.progress || 0;
+        const speed = t.speed ? t.speed.toFixed(2) : "";
+        tr.innerHTML = `
+            <td>${t.filename}</td>
+            <td>${t.state}</td>
+            <td>
+                <div class="progress">
+                    <div class="progress-bar" role="progressbar" style="width: ${progress}%" aria-valuenow="${progress}" aria-valuemin="0" aria-valuemax="100">${progress.toFixed(0)}%</div>
+                </div>
+            </td>
+            <td>${speed}</td>
+        `;
         tbody.appendChild(tr);
     });
 }
@@ -92,6 +132,7 @@ window.onload = function() {
     refreshVideos();
     loadLogs();
     fetchTasks();
+    fetchMaxConcurrent();
     setInterval(() => {
         fetchTasks();
         loadLogs();

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,11 +60,22 @@
     </div>
 
     <div class="card mb-4">
+        <div class="card-header">任务设置</div>
+        <div class="card-body">
+            <div class="mb-3">
+                <label class="form-label">最大并发任务</label>
+                <input type="number" id="maxConcurrent" class="form-control" min="1" />
+            </div>
+            <button class="btn btn-primary" onclick="setMaxConcurrent()">保存</button>
+        </div>
+    </div>
+
+    <div class="card mb-4">
         <div class="card-header">任务状态</div>
         <div class="card-body">
             <table class="table" id="taskTable">
                 <thead>
-                    <tr><th>文件</th><th>状态</th></tr>
+                    <tr><th>文件</th><th>状态</th><th>进度</th><th>速率(MB/s)</th></tr>
                 </thead>
                 <tbody></tbody>
             </table>


### PR DESCRIPTION
## Summary
- show progress and speed for compression tasks
- allow configuring max concurrent jobs
- track ffmpeg progress updates server-side

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6c421e70083329103464e8d21d00c