### PR TITLE
feat: improve task feedback and logging

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -90,10 +90,11 @@
                 <thead>
                     <tr>
                         <th>时间</th>
-                        <th>输入文件</th>
-                        <th>输出文件</th>
+                        <th>文件名</th>
                         <th>编码器</th>
                         <th>CRF</th>
+                        <th>压缩比例</th>
+                        <th>总用时(s)</th>
                         <th>结果</th>
                     </tr>
                 </thead>


### PR DESCRIPTION
## Summary
- log compression ratio and elapsed time for each compression task
- show single filename with ratio and total time in log table
- update task status every 5s with completion alerts

## Testing
- `python -m py_compile app/tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_68b7776dae788332ac025e57d0d67af6