### PR TITLE
feat: immediately display submitted tasks

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -71,6 +71,15 @@ async function compressSelected() {
                 continue;
             }
             const data = await res.json();
+            // 将新任务立即加入本地任务列表，避免等待下一次轮询
+            tasks.push({
+                task_id: data.task_id,
+                filename: cb.value,
+                state: "PENDING",
+                progress: 0,
+                speed: null
+            });
+            renderTasks();
             alert(`任务已提交: ${data.task_id}`);
         } catch (err) {
             console.error(err);


### PR DESCRIPTION
## Summary
- show new compression tasks in the task list as soon as they are submitted

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b70ce781488332bf0a743c299d0fcf