### PR TITLE
Add loading spinner overlay and fetch wrapper

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -82,3 +82,17 @@ body {
     font-size: 0.9rem;
 }
 
+/* Spinner overlay */
+.spinner-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.6);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 1050;
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,11 @@
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
+<div id="spinner" class="spinner-overlay">
+    <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+    </div>
+</div>
 <nav class="navbar navbar-expand-lg navbar-custom">
     <div class="container-fluid">
         <a class="navbar-brand" href="#">VideoCompress</a>


### PR DESCRIPTION
## Summary
- Add spinner overlay component to index template and style it centrally
- Wrap fetch calls with spinner visibility management for user feedback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b78c2245b083328496e92c5a578e85