### PR TITLE
Add DataTables plugin for task and log tables

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,5 +1,7 @@
 let tasks = [];
 let taskStates = {};
+let taskDataTable;
+let logDataTable;
 
 async function fetchMaxConcurrent() {
     const res = await fetch("/api/max_concurrent");
@@ -118,6 +120,12 @@ async function loadLogs() {
         `;
         tbody.appendChild(tr);
     });
+    if (logDataTable) {
+        logDataTable.destroy();
+    }
+    logDataTable = $('#logTable').DataTable({
+        order: [],
+    });
 }
 
 function renderTasks() {
@@ -138,6 +146,15 @@ function renderTasks() {
             <td>${speed}</td>
         `;
         tbody.appendChild(tr);
+    });
+    if (taskDataTable) {
+        taskDataTable.destroy();
+    }
+    taskDataTable = $('#taskTable').DataTable({
+        paging: false,
+        searching: false,
+        info: false,
+        order: [],
     });
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -82,3 +82,18 @@ body {
     font-size: 0.9rem;
 }
 
+/* DataTables custom styling */
+table.dataTable thead th {
+    background-color: var(--primary-color);
+    color: #ffffff;
+}
+
+table.dataTable tbody tr:hover {
+    background-color: #f1f1f1;
+}
+
+.dataTables_wrapper .dataTables_filter input {
+    border-radius: 4px;
+    padding: 0.25rem;
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>视频压缩服务器管理</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" rel="stylesheet">
     <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
@@ -113,6 +114,9 @@
         &copy; 2023 VideoCompress
     </div>
 </footer>
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
 <script src="/static/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Integrate DataTables library via CDN
- Initialize DataTables for task and log tables with jQuery
- Style tables for polished appearance

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b78c25e0cc8332b436ea6ade0587c5